### PR TITLE
fix(sdk): send the request body unchanged in the Vercel AI adapter

### DIFF
--- a/packages/sdk/src/frameworks/vercel-ai.ts
+++ b/packages/sdk/src/frameworks/vercel-ai.ts
@@ -26,7 +26,7 @@ export function agentiTools(config: AgentiToolsConfig): Record<string, any> {
       execute: async ({ url, method, body }) => {
         const response = await client.pay(url, {
           method: method ?? 'GET',
-          body: body ? JSON.parse(body) : undefined,
+          body: body ?? undefined,
         })
         return { status: response.status, body: await response.text() }
       },


### PR DESCRIPTION
Closes #120.

The Vercel AI adapter passed a parsed object as the request body:

```ts
body: body ? JSON.parse(body) : undefined,
```

`client.pay(url, options)` takes a `RequestInit`, whose `body` must be a `BodyInit` (string). `fetch` stringifies a non-`BodyInit` object with `String()`, so POST/PUT requests were sent with the literal body `[object Object]`.

The `body` tool-arg is documented as a JSON string, and the sibling LangChain adapter (`frameworks/langchain.ts`) already passes it through unchanged. This does the same:

```ts
body: body ?? undefined,
```
